### PR TITLE
Hotfix migration to rename table Restaurants

### DIFF
--- a/hiprest_app/app/models/restaurant.rb
+++ b/hiprest_app/app/models/restaurant.rb
@@ -1,0 +1,2 @@
+class Restaurant < ActiveRecord::Base
+end

--- a/hiprest_app/app/models/restraurant.rb
+++ b/hiprest_app/app/models/restraurant.rb
@@ -1,2 +1,0 @@
-class Restraurant < ActiveRecord::Base
-end

--- a/hiprest_app/db/migrate/20150609000626_rename_old_table_to_new_table.rb
+++ b/hiprest_app/db/migrate/20150609000626_rename_old_table_to_new_table.rb
@@ -1,0 +1,5 @@
+class RenameOldTableToNewTable < ActiveRecord::Migration
+  def change
+  	rename_table :restraurants, :restaurants
+  end
+end

--- a/hiprest_app/db/schema.rb
+++ b/hiprest_app/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150608204115) do
+ActiveRecord::Schema.define(version: 20150609000626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "restraurants", force: :cascade do |t|
+  create_table "restaurants", force: :cascade do |t|
     t.string   "name"
     t.string   "address"
     t.float    "vote"


### PR DESCRIPTION
Ran migration:

class RenameOldTableToNewTable < ActiveRecord::Migration
  def change
    rename_table :restraurants, :restaurants
  end
end

Then renamed model file and class name: Restaurant
